### PR TITLE
Fix multiple hyphens in pre-releases and add tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
     - name: Test with pytest
       run: |
         pip install pytest

--- a/enhanced_versioning/nonsemantic_version.py
+++ b/enhanced_versioning/nonsemantic_version.py
@@ -51,11 +51,15 @@ class NonSemanticVersion(BaseVersion):
             version, build = version.split(self.BUILD_DELIMITER)
             assert self.VALIDATION_REGEX.match(build)
             self.build = self._make_group(build)
+            # Assert that there are not any empty sequences in the build versions
+            assert '' not in self.build
         # Step 2: Try to split on '-' nad pull the pre-release version off.
         if self.PRE_RELEASE_DELIMITER in version:
-            version, pre_release = version.split(self.PRE_RELEASE_DELIMITER)
+            version, pre_release = version.split(self.PRE_RELEASE_DELIMITER, 1)
             assert self.VALIDATION_REGEX.match(pre_release)
             self.pre_release = self._make_group(pre_release)
+            # Assert that there are not any empty sequences in the pre-releases
+            assert '' not in self.pre_release
         # Step 3: Split on '.' and parse revisions until we run out.
         while self.REVISION_DELIMITER in version:
             rev, version = version.split(self.REVISION_DELIMITER, 1)

--- a/enhanced_versioning/test_nonsemantic_version.py
+++ b/enhanced_versioning/test_nonsemantic_version.py
@@ -27,6 +27,21 @@ def test_nonsemantic_versions():
     assert repr(NonSemanticVersion('999.abc.999.999')) == "NonSemanticVersion('999.abc.999.999')"
     assert str(NonSemanticVersion('999.abc.999.999f')) == '999.abc.999.999f'
     assert repr(NonSemanticVersion('999.abc.999.999f')) == "NonSemanticVersion('999.abc.999.999f')"
+    # Test multiple pre-releases and multiple hyphens in pre-releases
+    assert str(NonSemanticVersion('1.2.3.4-alpha-beta')) == '1.2.3.4-alpha-beta'
+    assert repr(NonSemanticVersion('1.2.3.4-alpha-beta')) == "NonSemanticVersion('1.2.3.4-alpha-beta')"
+    assert str(NonSemanticVersion('1.2.3-alpha-beta-gamma')) == '1.2.3-alpha-beta-gamma'
+    assert repr(NonSemanticVersion('1.2.3-alpha-beta-gamma')) == "NonSemanticVersion('1.2.3-alpha-beta-gamma')"
+    assert str(NonSemanticVersion('1.2.3-alpha-beta.gamma')) == '1.2.3-alpha-beta.gamma'
+    assert repr(NonSemanticVersion('1.2.3-alpha-beta.gamma')) == "NonSemanticVersion('1.2.3-alpha-beta.gamma')"
+
+    # Test multiple builds
+    assert str(NonSemanticVersion('1.2.3.4-alpha+beta')) == '1.2.3.4-alpha+beta'
+    assert repr(NonSemanticVersion('1.2.3.4-alpha+beta')) == "NonSemanticVersion('1.2.3.4-alpha+beta')"
+    assert str(NonSemanticVersion('1.2.3-alpha+beta-gamma')) == '1.2.3-alpha+beta-gamma'
+    assert repr(NonSemanticVersion('1.2.3-alpha+beta-gamma')) == "NonSemanticVersion('1.2.3-alpha+beta-gamma')"
+    assert str(NonSemanticVersion('1.2.3-alpha+beta.gamma')) == '1.2.3-alpha+beta.gamma'
+    assert repr(NonSemanticVersion('1.2.3-alpha+beta.gamma')) == "NonSemanticVersion('1.2.3-alpha+beta.gamma')"
 
     with raises(VersionError):
         NonSemanticVersion('_._._')
@@ -72,6 +87,8 @@ def test_section_9():
         NonSemanticVersion('1.0.0-')
     with raises(VersionError):
         NonSemanticVersion('1.0.0-$#%')
+    with raises(VersionError):
+        NonSemanticVersion('1.0.0.0-alpha..1').pre_release
 
     assert NonSemanticVersion('1.0.0') > NonSemanticVersion('1.0.0-alpha')
     assert NonSemanticVersion('1.0.0-alpha') < NonSemanticVersion('1.0.0')
@@ -94,6 +111,9 @@ def test_section_10():
     assert NonSemanticVersion('1.0.0+build.11.e0f985a').build == ['build', 11, 'e0f985a']
     assert NonSemanticVersion('1.0.0.f+build.1').build == ['build', 1]
     assert NonSemanticVersion('1.0.0.f+build.11.e0f985a').build == ['build', 11, 'e0f985a']
+
+    with raises(VersionError):
+        NonSemanticVersion('1.0.0.0-alpha+build.1..11')
 
 
 def test_section_11():


### PR DESCRIPTION
Update NonSemanticVersion to support multiple hyphens in pre-releases. Also asserting that there are not empty sequences in the pre-releases or builds.
Updated tests to test these cases.