### PR TITLE
Inherit from str for json serialization. Add tests

### DIFF
--- a/enhanced_versioning/base_version.py
+++ b/enhanced_versioning/base_version.py
@@ -45,7 +45,7 @@ class _Seq(_Comparable):
         return self.seq == other.seq
 
 
-class BaseVersion(_Comparable):
+class BaseVersion(_Comparable, str):
     """ Base version class """
     REVISION_DELIMITER = '.'
     PRE_RELEASE_DELIMITER = '-'

--- a/enhanced_versioning/test_nonsemantic_version.py
+++ b/enhanced_versioning/test_nonsemantic_version.py
@@ -1,3 +1,5 @@
+import json
+
 from pytest import raises
 
 from enhanced_versioning.base_version import VersionError
@@ -165,3 +167,24 @@ def test_comparing_against_non_version():
     with raises(TypeError) as exception:
         NonSemanticVersion('1.0.0') == object()
     assert 'cannot compare' in repr(exception.value)
+
+
+def test_json_serialization():
+    """Test json serialization.
+
+    """
+    assert json.dumps(NonSemanticVersion('0')) == '"0"'
+    assert json.dumps(NonSemanticVersion('1.2')) == '"1.2"'
+    assert json.dumps(NonSemanticVersion('0.0.0')) == '"0.0.0"'
+    assert json.dumps(NonSemanticVersion('999.999.999.999')) == '"999.999.999.999"'
+    assert json.dumps(NonSemanticVersion('999.abc.999.999')) == '"999.abc.999.999"'
+    assert json.dumps(NonSemanticVersion('999.abc.999.999f')) == '"999.abc.999.999f"'
+    # Test multiple pre-releases and multiple hyphens in pre-releases
+    assert json.dumps(NonSemanticVersion('1.2.3.4-alpha-beta')) == '"1.2.3.4-alpha-beta"'
+    assert json.dumps(NonSemanticVersion('1.2.3-alpha-beta-gamma')) == '"1.2.3-alpha-beta-gamma"'
+    assert json.dumps(NonSemanticVersion('1.2.3-alpha-beta.gamma')) == '"1.2.3-alpha-beta.gamma"'
+
+    # Test multiple builds
+    assert json.dumps(NonSemanticVersion('1.2.3.4-alpha+beta')) == '"1.2.3.4-alpha+beta"'
+    assert json.dumps(NonSemanticVersion('1.2.3-alpha+beta-gamma')) == '"1.2.3-alpha+beta-gamma"'
+    assert json.dumps(NonSemanticVersion('1.2.3-alpha+beta.gamma')) == '"1.2.3-alpha+beta.gamma"'

--- a/enhanced_versioning/test_semantic_version.py
+++ b/enhanced_versioning/test_semantic_version.py
@@ -1,3 +1,5 @@
+import json
+
 from pytest import raises
 
 from enhanced_versioning.base_version import VersionError
@@ -141,3 +143,15 @@ def test_comparing_against_non_version():
     with raises(TypeError) as exception:
         SemanticVersion('1.0.0') == object()
     assert 'cannot compare' in repr(exception.value)
+
+
+def test_json_serialization():
+    """Test json serialization.
+
+    """
+    assert json.dumps(SemanticVersion('0.0.0')) == '"0.0.0"'
+    assert json.dumps(SemanticVersion('999.999.999')) == '"999.999.999"'
+    assert json.dumps(SemanticVersion('1.0.0-alpha')) == '"1.0.0-alpha"'
+    assert json.dumps(SemanticVersion('1.0.0-alpha.1')) == '"1.0.0-alpha.1"'
+    assert json.dumps(SemanticVersion('1.0.0+build.1')) == '"1.0.0+build.1"'
+    assert json.dumps(SemanticVersion('1.0.0-alpha.beta-gamma+build.11.e0f985a')) == '"1.0.0-alpha.beta-gamma+build.11.e0f985a"'


### PR DESCRIPTION
Add support for json serializing versions. By inheriting from str, json can dump versions to strings. But json load will load it as a string.